### PR TITLE
Metadata Providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@lukehagar/plexjs": "^0.35.1",
         "@mui/material": "^6.4.7",
         "@mui/x-date-pickers": "^7.27.3",
+        "@uidotdev/usehooks": "^2.4.1",
         "classnames": "^2.5.1",
         "dayjs": "^1.11.13",
         "react": "^18.3.1",
@@ -35,7 +36,8 @@
         "prettier": "3.5.3",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
-        "vite": "^6.0.5"
+        "vite": "^6.0.5",
+        "zod": "^3.24.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1865,6 +1867,7 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2107,6 +2110,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -4075,21 +4091,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4107,8 +4108,8 @@
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@lukehagar/plexjs": "^0.35.1",
     "@mui/material": "^6.4.7",
     "@mui/x-date-pickers": "^7.27.3",
+    "@uidotdev/usehooks": "^2.4.1",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.13",
     "react": "^18.3.1",
@@ -37,6 +38,7 @@
     "prettier": "3.5.3",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "zod": "^3.24.2"
   }
 }

--- a/src/components/gamgee-app/gamgee-app.module.css
+++ b/src/components/gamgee-app/gamgee-app.module.css
@@ -15,4 +15,5 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
+    width: 600px;
 }

--- a/src/components/gamgee-app/gamgee-app.module.css
+++ b/src/components/gamgee-app/gamgee-app.module.css
@@ -1,0 +1,18 @@
+.appContainerOuter {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.appContainerInner {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 16px;
+}
+
+.providerContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}

--- a/src/components/gamgee-app/gamgee-app.module.css
+++ b/src/components/gamgee-app/gamgee-app.module.css
@@ -14,5 +14,5 @@
 .providerContainer {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 12px;
 }

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -1,6 +1,8 @@
 import { StingComponent } from "../sting-component/sting-component.tsx";
 import { useId, useState } from "react";
 import {
+  Alert,
+  capitalize,
   FormControl,
   InputLabel,
   MenuItem,
@@ -54,6 +56,7 @@ export const GamgeeApp = () => {
               timestamp={mediaTimerProperties.timestamp}
             />
           )}
+        <Alert severity="info">{capitalize(mediaTimerProperties.state)}</Alert>
         <FormControl className={styles.providerContainer}>
           <InputLabel id={providerLabelId}>{providerLabel}</InputLabel>
           <Select
@@ -68,13 +71,13 @@ export const GamgeeApp = () => {
               </MenuItem>
             ))}
           </Select>
-          {metadataProvider === "Manual" && (
-            <ManualMetadataProvider {...metadataProviderProps} />
-          )}
-          {metadataProvider === "Plex" && (
-            <PlexMetadataProvider {...metadataProviderProps} />
-          )}
         </FormControl>
+        {metadataProvider === "Manual" && (
+          <ManualMetadataProvider {...metadataProviderProps} />
+        )}
+        {metadataProvider === "Plex" && (
+          <PlexMetadataProvider {...metadataProviderProps} />
+        )}
       </div>
     </div>
   );

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -22,7 +22,7 @@ export const GamgeeApp = () => {
   const [metadataProvider, setMetadataProvider] =
     useState<MetadataProvider>("Manual");
   const [metadata, setMetadata] = useState<EditionMetadata | null>(null);
-  const { timer, timestamp } = useMediaTimer();
+  const { timer, timestamp, toggleTimerState } = useMediaTimer();
 
   const providerLabelId = useId();
   const providerLabel = "Metadata Provider";
@@ -38,6 +38,7 @@ export const GamgeeApp = () => {
     timer,
     editionMetadata: metadata,
     setEditionMetadata: setMetadata,
+    toggleTimerState,
   };
 
   return (

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -22,7 +22,7 @@ export const GamgeeApp = () => {
   const [metadataProvider, setMetadataProvider] =
     useState<MetadataProvider>("Manual");
   const [metadata, setMetadata] = useState<EditionMetadata | null>(null);
-  const { timer, timestamp, toggleTimerState } = useMediaTimer();
+  const { timer, timestamp, toggleTimerState, resetTimer } = useMediaTimer();
 
   const providerLabelId = useId();
   const providerLabel = "Metadata Provider";
@@ -39,6 +39,7 @@ export const GamgeeApp = () => {
     editionMetadata: metadata,
     setEditionMetadata: setMetadata,
     toggleTimerState,
+    resetTimer,
   };
 
   return (

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -22,8 +22,13 @@ export const GamgeeApp = () => {
   const [metadataProvider, setMetadataProvider] =
     useState<MetadataProvider>("Manual");
   const [metadata, setMetadata] = useState<EditionMetadata | null>(null);
-  const { timer, timestamp, toggleTimerState, resetTimer, seekTimer } =
-    useMediaTimer();
+  const {
+    timestamp,
+    toggleTimerState,
+    toggleTimerLabel,
+    resetTimer,
+    seekTimer,
+  } = useMediaTimer();
 
   const providerLabelId = useId();
   const providerLabel = "Metadata Provider";
@@ -36,10 +41,10 @@ export const GamgeeApp = () => {
   };
 
   const metadataProviderProps: MetadataProviderProps = {
-    timer,
     editionMetadata: metadata,
     setEditionMetadata: setMetadata,
     toggleTimerState,
+    toggleTimerLabel,
     resetTimer,
     seekTimer,
   };

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -1,5 +1,36 @@
 import { StingComponent } from "../sting-component/sting-component.tsx";
+import { useState } from "react";
+import { usePlex } from "../../hooks/plex/usePlex.ts";
+import { TextField } from "@mui/material";
+import { movies } from "../../movies/movies.ts";
 
 export const GamgeeApp = () => {
-  return <StingComponent />;
+  const movieEdition = movies["tt0167261"].editions.find(
+    (edition) => edition.label === "Extended Edition",
+  )!;
+
+  const [plexIp, setPlexIp] = useState("");
+  const [plexToken, setPlexToken] = useState("");
+  usePlex(plexIp, plexToken);
+
+  // Use imdbId to identify the movie playing, see movies.ts
+  // Use playerState to automatically pause/play our stopwatch
+  // Use estimatedPlayTime to keep our stopwatch in sync.
+
+  return (
+    <>
+      <StingComponent
+        differences={movieEdition.differences!}
+        chapters={movieEdition.chapters!}
+      />
+      <TextField
+        label="Plex IP"
+        onChange={(newIpEvent) => setPlexIp(newIpEvent.target.value)}
+      />
+      <TextField
+        label="Plex Token"
+        onChange={(newTokenEvent) => setPlexToken(newTokenEvent.target.value)}
+      />
+    </>
+  );
 };

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -1,5 +1,5 @@
 import { StingComponent } from "../sting-component/sting-component.tsx";
-import { useCallback, useId, useState } from "react";
+import { useId, useState } from "react";
 import {
   FormControl,
   InputLabel,
@@ -12,8 +12,8 @@ import {
   EditionMetadata,
   MetadataProviderProps,
 } from "../metadata-provider/metadata-provider.ts";
-import { useTimer } from "react-use-precision-timer";
 import styles from "./gamgee-app.module.css";
+import { useMediaTimer } from "../../hooks/media-timer/useMediaTimer.tsx";
 
 const metadataProviders = ["Manual"] as const;
 type MetadataProvider = (typeof metadataProviders)[number];
@@ -22,14 +22,7 @@ export const GamgeeApp = () => {
   const [metadataProvider, setMetadataProvider] =
     useState<MetadataProvider>("Manual");
   const [metadata, setMetadata] = useState<EditionMetadata | null>(null);
-  const [timestamp, setTimestamp] = useState<number>(0);
-
-  const updateElapsedTime = useCallback(() => {
-    const elapsed = timer.getElapsedRunningTime();
-    setTimestamp(elapsed);
-  }, []);
-
-  const timer = useTimer({ delay: 1000 / 24 }, updateElapsedTime);
+  const { timer, timestamp } = useMediaTimer();
 
   const providerLabelId = useId();
   const providerLabel = "Metadata Provider";

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -22,7 +22,8 @@ export const GamgeeApp = () => {
   const [metadataProvider, setMetadataProvider] =
     useState<MetadataProvider>("Manual");
   const [metadata, setMetadata] = useState<EditionMetadata | null>(null);
-  const { timer, timestamp, toggleTimerState, resetTimer } = useMediaTimer();
+  const { timer, timestamp, toggleTimerState, resetTimer, seekTimer } =
+    useMediaTimer();
 
   const providerLabelId = useId();
   const providerLabel = "Metadata Provider";
@@ -40,6 +41,7 @@ export const GamgeeApp = () => {
     setEditionMetadata: setMetadata,
     toggleTimerState,
     resetTimer,
+    seekTimer,
   };
 
   return (

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -22,13 +22,7 @@ export const GamgeeApp = () => {
   const [metadataProvider, setMetadataProvider] =
     useState<MetadataProvider>("Manual");
   const [metadata, setMetadata] = useState<EditionMetadata | null>(null);
-  const {
-    timestamp,
-    toggleTimerState,
-    toggleTimerLabel,
-    resetTimer,
-    seekTimer,
-  } = useMediaTimer();
+  const { mediaTimerProperties, mediaTimerActions } = useMediaTimer();
 
   const providerLabelId = useId();
   const providerLabel = "Metadata Provider";
@@ -43,10 +37,8 @@ export const GamgeeApp = () => {
   const metadataProviderProps: MetadataProviderProps = {
     editionMetadata: metadata,
     setEditionMetadata: setMetadata,
-    toggleTimerState,
-    toggleTimerLabel,
-    resetTimer,
-    seekTimer,
+    mediaTimerProperties,
+    mediaTimerActions,
   };
 
   return (
@@ -58,7 +50,7 @@ export const GamgeeApp = () => {
             <StingComponent
               differences={metadata.edition.differences}
               chapters={metadata.edition.chapters}
-              timestamp={timestamp}
+              timestamp={mediaTimerProperties.timestamp}
             />
           )}
         <FormControl className={styles.providerContainer}>

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -22,7 +22,7 @@ export const GamgeeApp = () => {
   const [metadataProvider, setMetadataProvider] =
     useState<MetadataProvider>("Manual");
   const [metadata, setMetadata] = useState<EditionMetadata | null>(null);
-  const { mediaTimerProperties, mediaTimerActions } = useMediaTimer();
+  const { mediaTimerProperties, mediaTimerActions } = useMediaTimer(24);
 
   const providerLabelId = useId();
   const providerLabel = "Metadata Provider";

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -1,0 +1,5 @@
+import { StingComponent } from "../sting-component/sting-component.tsx";
+
+export const GamgeeApp = () => {
+  return <StingComponent />;
+};

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -35,6 +35,7 @@ export const GamgeeApp = () => {
   ) => {
     setMetadataProvider(event.target.value as MetadataProvider);
     setMetadata(null);
+    mediaTimerActions.stop();
   };
 
   const metadataProviderProps: MetadataProviderProps = {

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -58,7 +58,7 @@ export const GamgeeApp = () => {
             />
           )}
         <Alert severity="info">{capitalize(mediaTimerProperties.state)}</Alert>
-        <FormControl className={styles.providerContainer}>
+        <FormControl>
           <InputLabel id={providerLabelId}>{providerLabel}</InputLabel>
           <Select
             value={metadataProvider}
@@ -73,12 +73,14 @@ export const GamgeeApp = () => {
             ))}
           </Select>
         </FormControl>
-        {metadataProvider === "Manual" && (
-          <ManualMetadataProvider {...metadataProviderProps} />
-        )}
-        {metadataProvider === "Plex" && (
-          <PlexMetadataProvider {...metadataProviderProps} />
-        )}
+        <div className={styles.providerContainer}>
+          {metadataProvider === "Manual" && (
+            <ManualMetadataProvider {...metadataProviderProps} />
+          )}
+          {metadataProvider === "Plex" && (
+            <PlexMetadataProvider {...metadataProviderProps} />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/gamgee-app/gamgee-app.tsx
+++ b/src/components/gamgee-app/gamgee-app.tsx
@@ -8,6 +8,7 @@ import {
   SelectChangeEvent,
 } from "@mui/material";
 import { ManualMetadataProvider } from "../manual-metadata-provider/manual-metadata-provider.tsx";
+import { PlexMetadataProvider } from "../plex-metadata-provider/plex-metadata-provider.tsx";
 import {
   EditionMetadata,
   MetadataProviderProps,
@@ -15,7 +16,7 @@ import {
 import styles from "./gamgee-app.module.css";
 import { useMediaTimer } from "../../hooks/media-timer/useMediaTimer.tsx";
 
-const metadataProviders = ["Manual"] as const;
+const metadataProviders = ["Manual", "Plex"] as const;
 type MetadataProvider = (typeof metadataProviders)[number];
 
 export const GamgeeApp = () => {
@@ -69,6 +70,9 @@ export const GamgeeApp = () => {
           </Select>
           {metadataProvider === "Manual" && (
             <ManualMetadataProvider {...metadataProviderProps} />
+          )}
+          {metadataProvider === "Plex" && (
+            <PlexMetadataProvider {...metadataProviderProps} />
           )}
         </FormControl>
       </div>

--- a/src/components/manual-metadata-provider/manual-metadata-provider.module.css
+++ b/src/components/manual-metadata-provider/manual-metadata-provider.module.css
@@ -1,0 +1,6 @@
+.timeProvider {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    justify-content: space-between;
+}

--- a/src/components/manual-metadata-provider/manual-metadata-provider.tsx
+++ b/src/components/manual-metadata-provider/manual-metadata-provider.tsx
@@ -19,6 +19,7 @@ export const ManualMetadataProvider = ({
   setEditionMetadata,
   toggleTimerState,
   resetTimer,
+  seekTimer,
 }: ManualMetadataProviderProps) => {
   return (
     <>
@@ -30,6 +31,7 @@ export const ManualMetadataProvider = ({
         timer={timer}
         toggleTimerState={toggleTimerState}
         resetTimer={resetTimer}
+        seekTimer={seekTimer}
         disabled={!editionMetadata}
       />
     </>
@@ -111,6 +113,7 @@ export const ManualTimeProvider = ({
   timer,
   toggleTimerState,
   resetTimer,
+  seekTimer,
   disabled,
 }: ManualTimeProviderProps) => {
   const [seekTimerValue, setSeekTimerValue] = useState<Dayjs>(
@@ -138,17 +141,7 @@ export const ManualTimeProvider = ({
       <button
         disabled={disabled || !seekTimerValue || !seekTimerValue.isValid()}
         onClick={() => {
-          if (seekTimerValue) {
-            const currentEpochMillis = dayjsUtc().valueOf();
-            const selectedMillis = seekTimerValue.valueOf();
-            const startTime = currentEpochMillis - selectedMillis;
-            if (timer.isRunning()) {
-              timer.start(startTime);
-            } else {
-              timer.start(startTime);
-              timer.pause();
-            }
-          }
+          if (seekTimerValue) seekTimer(seekTimerValue.valueOf());
         }}
       >
         Seek

--- a/src/components/manual-metadata-provider/manual-metadata-provider.tsx
+++ b/src/components/manual-metadata-provider/manual-metadata-provider.tsx
@@ -18,6 +18,7 @@ export const ManualMetadataProvider = ({
   editionMetadata,
   setEditionMetadata,
   toggleTimerState,
+  resetTimer,
 }: ManualMetadataProviderProps) => {
   return (
     <>
@@ -28,6 +29,7 @@ export const ManualMetadataProvider = ({
       <ManualTimeProvider
         timer={timer}
         toggleTimerState={toggleTimerState}
+        resetTimer={resetTimer}
         disabled={!editionMetadata}
       />
     </>
@@ -108,6 +110,7 @@ export type ManualTimeProviderProps = TimeProviderProps & { disabled: boolean };
 export const ManualTimeProvider = ({
   timer,
   toggleTimerState,
+  resetTimer,
   disabled,
 }: ManualTimeProviderProps) => {
   const [seekTimerValue, setSeekTimerValue] = useState<Dayjs>(
@@ -119,16 +122,7 @@ export const ManualTimeProvider = ({
       <button disabled={disabled} onClick={toggleTimerState}>
         {!timer.isStarted() ? "Start" : timer.isRunning() ? "Pause" : "Resume"}
       </button>
-      <button
-        disabled={disabled}
-        onClick={() => {
-          if (timer.isRunning()) {
-            timer.start();
-          } else {
-            timer.stop();
-          }
-        }}
-      >
+      <button disabled={disabled} onClick={resetTimer}>
         Reset
       </button>
       <LocalizationProvider dateAdapter={AdapterDayjs}>

--- a/src/components/manual-metadata-provider/manual-metadata-provider.tsx
+++ b/src/components/manual-metadata-provider/manual-metadata-provider.tsx
@@ -17,6 +17,7 @@ export const ManualMetadataProvider = ({
   timer,
   editionMetadata,
   setEditionMetadata,
+  toggleTimerState,
 }: ManualMetadataProviderProps) => {
   return (
     <>
@@ -24,7 +25,11 @@ export const ManualMetadataProvider = ({
         editionMetadata={editionMetadata}
         setEditionMetadata={setEditionMetadata}
       />
-      <ManualTimeProvider timer={timer} disabled={!editionMetadata} />
+      <ManualTimeProvider
+        timer={timer}
+        toggleTimerState={toggleTimerState}
+        disabled={!editionMetadata}
+      />
     </>
   );
 };
@@ -102,6 +107,7 @@ export type ManualTimeProviderProps = TimeProviderProps & { disabled: boolean };
 
 export const ManualTimeProvider = ({
   timer,
+  toggleTimerState,
   disabled,
 }: ManualTimeProviderProps) => {
   const [seekTimerValue, setSeekTimerValue] = useState<Dayjs>(
@@ -110,18 +116,7 @@ export const ManualTimeProvider = ({
 
   return (
     <div className={styles.timeProvider}>
-      <button
-        disabled={disabled}
-        onClick={() => {
-          if (!timer.isStarted()) {
-            timer.start();
-          } else if (timer.isRunning()) {
-            timer.pause();
-          } else {
-            timer.resume();
-          }
-        }}
-      >
+      <button disabled={disabled} onClick={toggleTimerState}>
         {!timer.isStarted() ? "Start" : timer.isRunning() ? "Pause" : "Resume"}
       </button>
       <button

--- a/src/components/manual-metadata-provider/manual-metadata-provider.tsx
+++ b/src/components/manual-metadata-provider/manual-metadata-provider.tsx
@@ -14,13 +14,10 @@ import styles from "./manual-metadata-provider.module.css";
 export type ManualMetadataProviderProps = MetadataProviderProps;
 
 export const ManualMetadataProvider = ({
-  timer,
   editionMetadata,
   setEditionMetadata,
-  toggleTimerState,
-  toggleTimerLabel,
-  resetTimer,
-  seekTimer,
+  mediaTimerProperties,
+  mediaTimerActions,
 }: ManualMetadataProviderProps) => {
   return (
     <>
@@ -29,11 +26,8 @@ export const ManualMetadataProvider = ({
         setEditionMetadata={setEditionMetadata}
       />
       <ManualTimeProvider
-        timer={timer}
-        toggleTimerState={toggleTimerState}
-        toggleTimerLabel={toggleTimerLabel}
-        resetTimer={resetTimer}
-        seekTimer={seekTimer}
+        mediaTimerProperties={mediaTimerProperties}
+        mediaTimerActions={mediaTimerActions}
         disabled={!editionMetadata}
       />
     </>
@@ -112,22 +106,23 @@ export const ManualEditionMetadataProvider = ({
 export type ManualTimeProviderProps = TimeProviderProps & { disabled: boolean };
 
 export const ManualTimeProvider = ({
-  toggleTimerState,
-  toggleTimerLabel,
-  resetTimer,
-  seekTimer,
+  mediaTimerProperties,
+  mediaTimerActions,
   disabled,
 }: ManualTimeProviderProps) => {
   const [seekTimerValue, setSeekTimerValue] = useState<Dayjs>(
     dayjsUtc("1970-01-01"),
   );
 
+  const { toggleLabel } = mediaTimerProperties;
+  const { reset, seek, toggle } = mediaTimerActions;
+
   return (
     <div className={styles.timeProvider}>
-      <button disabled={disabled} onClick={toggleTimerState}>
-        {toggleTimerLabel}
+      <button disabled={disabled} onClick={toggle}>
+        {toggleLabel}
       </button>
-      <button disabled={disabled} onClick={resetTimer}>
+      <button disabled={disabled} onClick={reset}>
         Reset
       </button>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -143,7 +138,7 @@ export const ManualTimeProvider = ({
       <button
         disabled={disabled || !seekTimerValue || !seekTimerValue.isValid()}
         onClick={() => {
-          if (seekTimerValue) seekTimer(seekTimerValue.valueOf());
+          if (seekTimerValue) seek(seekTimerValue.valueOf());
         }}
       >
         Seek

--- a/src/components/manual-metadata-provider/manual-metadata-provider.tsx
+++ b/src/components/manual-metadata-provider/manual-metadata-provider.tsx
@@ -18,6 +18,7 @@ export const ManualMetadataProvider = ({
   editionMetadata,
   setEditionMetadata,
   toggleTimerState,
+  toggleTimerLabel,
   resetTimer,
   seekTimer,
 }: ManualMetadataProviderProps) => {
@@ -30,6 +31,7 @@ export const ManualMetadataProvider = ({
       <ManualTimeProvider
         timer={timer}
         toggleTimerState={toggleTimerState}
+        toggleTimerLabel={toggleTimerLabel}
         resetTimer={resetTimer}
         seekTimer={seekTimer}
         disabled={!editionMetadata}
@@ -110,8 +112,8 @@ export const ManualEditionMetadataProvider = ({
 export type ManualTimeProviderProps = TimeProviderProps & { disabled: boolean };
 
 export const ManualTimeProvider = ({
-  timer,
   toggleTimerState,
+  toggleTimerLabel,
   resetTimer,
   seekTimer,
   disabled,
@@ -123,7 +125,7 @@ export const ManualTimeProvider = ({
   return (
     <div className={styles.timeProvider}>
       <button disabled={disabled} onClick={toggleTimerState}>
-        {!timer.isStarted() ? "Start" : timer.isRunning() ? "Pause" : "Resume"}
+        {toggleTimerLabel}
       </button>
       <button disabled={disabled} onClick={resetTimer}>
         Reset

--- a/src/components/manual-metadata-provider/manual-metadata-provider.tsx
+++ b/src/components/manual-metadata-provider/manual-metadata-provider.tsx
@@ -1,0 +1,169 @@
+import {
+  EditionProviderProps,
+  MetadataProviderProps,
+  TimeProviderProps,
+} from "../metadata-provider/metadata-provider.ts";
+import { LocalizationProvider, TimeField } from "@mui/x-date-pickers";
+import { useId, useState } from "react";
+import dayjsUtc, { Dayjs } from "../../utils/dayjs-config.ts";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import { movies } from "../../movies/movies.ts";
+import styles from "./manual-metadata-provider.module.css";
+
+export type ManualMetadataProviderProps = MetadataProviderProps;
+
+export const ManualMetadataProvider = ({
+  timer,
+  editionMetadata,
+  setEditionMetadata,
+}: ManualMetadataProviderProps) => {
+  return (
+    <>
+      <ManualEditionMetadataProvider
+        editionMetadata={editionMetadata}
+        setEditionMetadata={setEditionMetadata}
+      />
+      <ManualTimeProvider timer={timer} disabled={!editionMetadata} />
+    </>
+  );
+};
+
+export const ManualEditionMetadataProvider = ({
+  editionMetadata,
+  setEditionMetadata,
+}: EditionProviderProps) => {
+  const movieLabelId = useId();
+  const movieLabel = "Movie";
+
+  const editionLabelId = useId();
+  const editionLabel = "Edition";
+
+  return (
+    <>
+      <FormControl fullWidth>
+        <InputLabel id={movieLabelId}>{movieLabel}</InputLabel>
+        <Select
+          value={editionMetadata?.movie.imdbId ?? ""}
+          id={movieLabelId}
+          label={movieLabel}
+          onChange={(imdbId) => {
+            const movie = movies.find((m) => m.imdbId === imdbId.target.value);
+
+            if (!movie) return;
+            const foundSameEdition = movie.editions.find(
+              (e) => e.label === editionMetadata?.edition.label,
+            );
+            const edition = foundSameEdition ?? movie.editions[0];
+
+            setEditionMetadata({
+              movie,
+              edition,
+            });
+          }}
+        >
+          {movies.map((movie) => (
+            <MenuItem key={movie.imdbId} value={movie.imdbId}>
+              {movie.title}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl fullWidth>
+        <InputLabel id={editionLabelId}>{editionLabel}</InputLabel>
+        <Select
+          value={editionMetadata?.edition.label ?? ""}
+          id={editionLabelId}
+          label={editionLabel}
+          disabled={!editionMetadata}
+          onChange={(label) => {
+            if (!editionMetadata) return;
+            const movie = editionMetadata.movie;
+            const edition = movie.editions.find(
+              (e) => e.label === label.target.value,
+            );
+
+            if (!edition) return;
+            setEditionMetadata({ movie, edition });
+          }}
+        >
+          {editionMetadata?.movie.editions.map((edition) => (
+            <MenuItem key={edition.label} value={edition.label}>
+              {edition.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </>
+  );
+};
+
+export type ManualTimeProviderProps = TimeProviderProps & { disabled: boolean };
+
+export const ManualTimeProvider = ({
+  timer,
+  disabled,
+}: ManualTimeProviderProps) => {
+  const [seekTimerValue, setSeekTimerValue] = useState<Dayjs>(
+    dayjsUtc("1970-01-01"),
+  );
+
+  return (
+    <div className={styles.timeProvider}>
+      <button
+        disabled={disabled}
+        onClick={() => {
+          if (!timer.isStarted()) {
+            timer.start();
+          } else if (timer.isRunning()) {
+            timer.pause();
+          } else {
+            timer.resume();
+          }
+        }}
+      >
+        {!timer.isStarted() ? "Start" : timer.isRunning() ? "Pause" : "Resume"}
+      </button>
+      <button
+        disabled={disabled}
+        onClick={() => {
+          if (timer.isRunning()) {
+            timer.start();
+          } else {
+            timer.stop();
+          }
+        }}
+      >
+        Reset
+      </button>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <TimeField
+          disabled={disabled}
+          value={seekTimerValue}
+          onChange={(newSeekTimerValue) => {
+            if (newSeekTimerValue) setSeekTimerValue(newSeekTimerValue);
+          }}
+          format="HH:mm:ss"
+        />
+      </LocalizationProvider>
+      <button
+        disabled={disabled || !seekTimerValue || !seekTimerValue.isValid()}
+        onClick={() => {
+          if (seekTimerValue) {
+            const currentEpochMillis = dayjsUtc().valueOf();
+            const selectedMillis = seekTimerValue.valueOf();
+            const startTime = currentEpochMillis - selectedMillis;
+            if (timer.isRunning()) {
+              timer.start(startTime);
+            } else {
+              timer.start(startTime);
+              timer.pause();
+            }
+          }
+        }}
+      >
+        Seek
+      </button>
+    </div>
+  );
+};

--- a/src/components/metadata-provider/metadata-provider.ts
+++ b/src/components/metadata-provider/metadata-provider.ts
@@ -3,6 +3,7 @@ import { Timer } from "react-use-precision-timer";
 
 export type TimeProviderProps = {
   timer: Timer;
+  toggleTimerState: () => void;
 };
 
 export type EditionMetadata = {

--- a/src/components/metadata-provider/metadata-provider.ts
+++ b/src/components/metadata-provider/metadata-provider.ts
@@ -1,10 +1,12 @@
 import { Movie, MovieEdition } from "../../movies/movies.ts";
+import {
+  MediaTimerActions,
+  MediaTimerProperties,
+} from "../../hooks/media-timer/useMediaTimer.tsx";
 
 export type TimeProviderProps = {
-  toggleTimerState: () => void;
-  toggleTimerLabel: string;
-  resetTimer: () => void;
-  seekTimer: (milliseconds: number) => void;
+  mediaTimerProperties: MediaTimerProperties;
+  mediaTimerActions: MediaTimerActions;
 };
 
 export type EditionMetadata = {

--- a/src/components/metadata-provider/metadata-provider.ts
+++ b/src/components/metadata-provider/metadata-provider.ts
@@ -1,0 +1,18 @@
+import { Movie, MovieEdition } from "../../movies/movies.ts";
+import { Timer } from "react-use-precision-timer";
+
+export type TimeProviderProps = {
+  timer: Timer;
+};
+
+export type EditionMetadata = {
+  movie: Movie;
+  edition: MovieEdition;
+};
+
+export type EditionProviderProps = {
+  editionMetadata: EditionMetadata | null;
+  setEditionMetadata: (metadata: EditionMetadata) => void;
+};
+
+export type MetadataProviderProps = TimeProviderProps & EditionProviderProps;

--- a/src/components/metadata-provider/metadata-provider.ts
+++ b/src/components/metadata-provider/metadata-provider.ts
@@ -16,7 +16,7 @@ export type EditionMetadata = {
 
 export type EditionProviderProps = {
   editionMetadata: EditionMetadata | null;
-  setEditionMetadata: (metadata: EditionMetadata) => void;
+  setEditionMetadata: (metadata: EditionMetadata | null) => void;
 };
 
 export type MetadataProviderProps = TimeProviderProps & EditionProviderProps;

--- a/src/components/metadata-provider/metadata-provider.ts
+++ b/src/components/metadata-provider/metadata-provider.ts
@@ -4,6 +4,7 @@ import { Timer } from "react-use-precision-timer";
 export type TimeProviderProps = {
   timer: Timer;
   toggleTimerState: () => void;
+  resetTimer: () => void;
 };
 
 export type EditionMetadata = {

--- a/src/components/metadata-provider/metadata-provider.ts
+++ b/src/components/metadata-provider/metadata-provider.ts
@@ -5,6 +5,7 @@ export type TimeProviderProps = {
   timer: Timer;
   toggleTimerState: () => void;
   resetTimer: () => void;
+  seekTimer: (milliseconds: number) => void;
 };
 
 export type EditionMetadata = {

--- a/src/components/metadata-provider/metadata-provider.ts
+++ b/src/components/metadata-provider/metadata-provider.ts
@@ -1,9 +1,8 @@
 import { Movie, MovieEdition } from "../../movies/movies.ts";
-import { Timer } from "react-use-precision-timer";
 
 export type TimeProviderProps = {
-  timer: Timer;
   toggleTimerState: () => void;
+  toggleTimerLabel: string;
   resetTimer: () => void;
   seekTimer: (milliseconds: number) => void;
 };

--- a/src/components/plex-metadata-provider/plex-metadata-provider.tsx
+++ b/src/components/plex-metadata-provider/plex-metadata-provider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId } from "react";
 import { usePlex } from "../../hooks/plex/usePlex.ts";
 import {
   FormControl,
@@ -19,11 +19,15 @@ export const PlexMetadataProvider = ({
   mediaTimerProperties,
   mediaTimerActions,
 }: PlexMetadataProviderProps) => {
-  const [plexIp, setPlexIp] = useState("");
-  const [plexToken, setPlexToken] = useState("");
-  const [protocol, setProtocol] = useState<ServerProtocol>("http");
-  const { error, estimatedPlayTime, imdbId, mediaDuration, playerState } =
-    usePlex(plexIp, plexToken, protocol);
+  const {
+    error,
+    estimatedPlayTime,
+    imdbId,
+    mediaDuration,
+    playerState,
+    plexApiOptions,
+    setPlexApiOptions,
+  } = usePlex();
 
   const { timestamp } = mediaTimerProperties;
   const { seek } = mediaTimerActions;
@@ -60,11 +64,14 @@ export const PlexMetadataProvider = ({
       <FormControl fullWidth>
         <InputLabel id={protocolLabelId}>{protocolLabel}</InputLabel>
         <Select
-          value={protocol}
+          value={plexApiOptions.protocol}
           id={protocolLabelId}
           label={protocolLabel}
-          onChange={(newProtocol) =>
-            setProtocol(newProtocol.target.value as ServerProtocol)
+          onChange={(newProtocolEvent) =>
+            setPlexApiOptions((options) => ({
+              ...options,
+              protocol: newProtocolEvent.target.value as ServerProtocol,
+            }))
           }
         >
           {Object.values(ServerProtocol).map((protocol) => (
@@ -75,12 +82,24 @@ export const PlexMetadataProvider = ({
         </Select>
       </FormControl>
       <TextField
+        value={plexApiOptions.ip}
         label="Plex IP"
-        onChange={(newIpEvent) => setPlexIp(newIpEvent.target.value)}
+        onChange={(newIpEvent) =>
+          setPlexApiOptions((options) => ({
+            ...options,
+            ip: newIpEvent.target.value,
+          }))
+        }
       />
       <TextField
+        value={plexApiOptions.accessToken}
         label="Plex Token"
-        onChange={(newTokenEvent) => setPlexToken(newTokenEvent.target.value)}
+        onChange={(newTokenEvent) =>
+          setPlexApiOptions((options) => ({
+            ...options,
+            accessToken: newTokenEvent.target.value,
+          }))
+        }
       />
     </>
   );

--- a/src/components/plex-metadata-provider/plex-metadata-provider.tsx
+++ b/src/components/plex-metadata-provider/plex-metadata-provider.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useId, useState } from "react";
+import { usePlex } from "../../hooks/plex/usePlex.ts";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from "@mui/material";
+import { MetadataProviderProps } from "../metadata-provider/metadata-provider.ts";
+import { movies } from "../../movies/movies.ts";
+import { ServerProtocol } from "@lukehagar/plexjs/src/lib/config.ts";
+
+export type PlexMetadataProviderProps = MetadataProviderProps;
+
+export const PlexMetadataProvider = ({
+  editionMetadata,
+  setEditionMetadata,
+  mediaTimerProperties,
+  mediaTimerActions,
+}: PlexMetadataProviderProps) => {
+  const [plexIp, setPlexIp] = useState("");
+  const [plexToken, setPlexToken] = useState("");
+  const [protocol, setProtocol] = useState<ServerProtocol>("http");
+  const { error, estimatedPlayTime, imdbId, mediaDuration, playerState } =
+    usePlex(plexIp, plexToken, protocol);
+
+  const { timestamp } = mediaTimerProperties;
+  const { seek } = mediaTimerActions;
+
+  useEffect(() => {
+    const movie = movies.find((m) => m.imdbId === imdbId);
+    const edition = movie?.editions.find((e) => e.duration === mediaDuration);
+    if (
+      movie &&
+      edition &&
+      (editionMetadata?.movie !== movie || editionMetadata?.edition !== edition)
+    ) {
+      setEditionMetadata({ movie, edition });
+    }
+  }, [imdbId, mediaDuration]);
+
+  useEffect(() => {
+    if (
+      playerState === "paused" ||
+      (playerState === "playing" && estimatedPlayTime > timestamp)
+    ) {
+      seek(estimatedPlayTime);
+    }
+  }, [playerState, estimatedPlayTime]);
+
+  const protocolLabelId = useId();
+  const protocolLabel = "Protocol";
+
+  return (
+    <>
+      {imdbId}
+      {playerState}
+      {error?.message}
+      <FormControl fullWidth>
+        <InputLabel id={protocolLabelId}>{protocolLabel}</InputLabel>
+        <Select
+          value={protocol}
+          id={protocolLabelId}
+          label={protocolLabel}
+          onChange={(newProtocol) =>
+            setProtocol(newProtocol.target.value as ServerProtocol)
+          }
+        >
+          {Object.values(ServerProtocol).map((protocol) => (
+            <MenuItem key={protocol} value={protocol}>
+              {protocol}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <TextField
+        label="Plex IP"
+        onChange={(newIpEvent) => setPlexIp(newIpEvent.target.value)}
+      />
+      <TextField
+        label="Plex Token"
+        onChange={(newTokenEvent) => setPlexToken(newTokenEvent.target.value)}
+      />
+    </>
+  );
+};

--- a/src/components/plex-metadata-provider/plex-metadata-provider.tsx
+++ b/src/components/plex-metadata-provider/plex-metadata-provider.tsx
@@ -45,6 +45,7 @@ export const PlexMetadataProvider = ({
 
     if (playerState !== "playing") {
       stop();
+      setEditionMetadata(null);
       return;
     }
 

--- a/src/components/sting-component/sting-component.tsx
+++ b/src/components/sting-component/sting-component.tsx
@@ -1,27 +1,21 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import styles from "./sting-component.module.css";
 import { StingSword } from "../sting-sword/sting-sword";
-import { Timer, useTimer } from "react-use-precision-timer";
 import { EditionChapter, EditionDifferenceData } from "../../movies/movies.ts";
+import dayjsUtc from "../../utils/dayjs-config.ts";
 
 interface StingComponentProps {
   differences: EditionDifferenceData[];
   chapters: EditionChapter[];
+  timestamp: number;
 }
 
 export const StingComponent = ({
   differences,
   chapters,
+  timestamp,
 }: StingComponentProps) => {
   const [swordIsGlowing, setSwordIsGlowing] = useState<boolean>(false);
-
-  const updateElapsedTime = useCallback(() => {
-    const elapsed = timer.getElapsedRunningTime();
-    setElapsedTime(elapsed);
-  }, []);
-
-  const timer: Timer = useTimer({ delay: 1000 / 24 }, updateElapsedTime);
-  const [elapsedTime, setElapsedTime] = useState<number>(0);
 
   const getDifference = (time: number) =>
     differences.find(
@@ -30,26 +24,16 @@ export const StingComponent = ({
     );
 
   useEffect(() => {
-    const maybeDifference = getDifference(elapsedTime);
+    const maybeDifference = getDifference(timestamp);
     if (maybeDifference && !swordIsGlowing) {
       setSwordIsGlowing(true);
     } else if (!maybeDifference && swordIsGlowing) {
       setSwordIsGlowing(false);
     }
-  }, [elapsedTime]);
+  }, [timestamp]);
 
-  const nextChapterIndex = chapters.findIndex(
-    (c) => c.start_time_ms > elapsedTime,
-  );
-
-  const chapter = chapters[nextChapterIndex - 1];
-  const chapterInfo = chapter.title;
-
-  useEffect(() => timer.start(), []);
-
-  const hours = Math.floor(elapsedTime / (1000 * 60 * 60)) % 24;
-  const minutes = Math.floor(elapsedTime / (1000 * 60)) % 60;
-  const seconds = Math.floor(elapsedTime / 1000) % 60;
+  const chapter = chapters.findLast((c) => c.start_time_ms <= timestamp);
+  const chapterInfo = chapter?.title ?? "Unknown Chapter";
 
   return (
     <div className={styles.stingAppContainer}>
@@ -58,9 +42,7 @@ export const StingComponent = ({
       </div>
       <StingSword swordIsGlowing={swordIsGlowing} />
       <div>
-        <span>
-          {hours}:{minutes}.{seconds}
-        </span>
+        <span>{dayjsUtc(timestamp).format("HH:mm:ss")}</span>
       </div>
     </div>
   );

--- a/src/components/sting-component/sting-component.tsx
+++ b/src/components/sting-component/sting-component.tsx
@@ -1,12 +1,18 @@
-import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import styles from "./sting-component.module.css";
 import { StingSword } from "../sting-sword/sting-sword";
-import { TextField } from "@mui/material";
-import { usePlex } from "../../hooks/plex/usePlex.ts";
-import { movies } from "../../movies/movies.ts";
-import { useTimer, Timer } from "react-use-precision-timer";
+import { Timer, useTimer } from "react-use-precision-timer";
+import { EditionChapter, EditionDifferenceData } from "../../movies/movies.ts";
 
-export const StingComponent: FC = () => {
+interface StingComponentProps {
+  differences: EditionDifferenceData[];
+  chapters: EditionChapter[];
+}
+
+export const StingComponent = ({
+  differences,
+  chapters,
+}: StingComponentProps) => {
   const [swordIsGlowing, setSwordIsGlowing] = useState<boolean>(false);
 
   const updateElapsedTime = useCallback(() => {
@@ -18,7 +24,7 @@ export const StingComponent: FC = () => {
   const [elapsedTime, setElapsedTime] = useState<number>(0);
 
   const getDifference = (time: number) =>
-    differencesList.find(
+    differences.find(
       (difference) =>
         difference.start_time_ms < time && difference.end_time_ms > time,
     );
@@ -32,18 +38,11 @@ export const StingComponent: FC = () => {
     }
   }, [elapsedTime]);
 
-  const movieEdition = movies["tt0167261"].editions.find(
-    (edition) => edition.label === "Extended Edition",
-  )!;
-
-  const chaptersList = movieEdition.chapters!;
-  const differencesList = movieEdition.differences!;
-
-  const nextChapterIndex = chaptersList.findIndex(
+  const nextChapterIndex = chapters.findIndex(
     (c) => c.start_time_ms > elapsedTime,
   );
 
-  const chapter = chaptersList[nextChapterIndex - 1];
+  const chapter = chapters[nextChapterIndex - 1];
   const chapterInfo = chapter.title;
 
   useEffect(() => timer.start(), []);
@@ -51,14 +50,6 @@ export const StingComponent: FC = () => {
   const hours = Math.floor(elapsedTime / (1000 * 60 * 60)) % 24;
   const minutes = Math.floor(elapsedTime / (1000 * 60)) % 60;
   const seconds = Math.floor(elapsedTime / 1000) % 60;
-
-  const [plexIp, setPlexIp] = useState("");
-  const [plexToken, setPlexToken] = useState("");
-  usePlex(plexIp, plexToken);
-
-  // Use imdbId to identify the movie playing, see movies.ts
-  // Use playerState to automatically pause/play our stopwatch
-  // Use estimatedPlayTime to keep our stopwatch in sync.
 
   return (
     <div className={styles.stingAppContainer}>
@@ -71,14 +62,6 @@ export const StingComponent: FC = () => {
           {hours}:{minutes}.{seconds}
         </span>
       </div>
-      <TextField
-        label="Plex IP"
-        onChange={(newIpEvent) => setPlexIp(newIpEvent.target.value)}
-      />
-      <TextField
-        label="Plex Token"
-        onChange={(newTokenEvent) => setPlexToken(newTokenEvent.target.value)}
-      />
     </div>
   );
 };

--- a/src/hooks/media-timer/useMediaTimer.tsx
+++ b/src/hooks/media-timer/useMediaTimer.tsx
@@ -11,5 +11,15 @@ export const useMediaTimer = () => {
 
   const timer = useTimer({ delay: 1000 / 24 }, updateElapsedTime);
 
-  return { timer, timestamp };
+  const toggleTimerState = () => {
+    if (!timer.isStarted()) {
+      timer.start();
+    } else if (timer.isRunning()) {
+      timer.pause();
+    } else {
+      timer.resume();
+    }
+  };
+
+  return { timer, timestamp, toggleTimerState };
 };

--- a/src/hooks/media-timer/useMediaTimer.tsx
+++ b/src/hooks/media-timer/useMediaTimer.tsx
@@ -2,7 +2,23 @@ import { useTimer } from "react-use-precision-timer";
 import { useCallback, useState } from "react";
 import dayjsUtc from "../../utils/dayjs-config.ts";
 
-export const useMediaTimer = () => {
+export interface MediaTimerProperties {
+  timestamp: number;
+  toggleLabel: string;
+}
+
+export interface MediaTimerActions {
+  toggle: () => void;
+  reset: () => void;
+  seek: (milliseconds: number) => void;
+}
+
+interface UseMediaTimerProps {
+  mediaTimerProperties: MediaTimerProperties;
+  mediaTimerActions: MediaTimerActions;
+}
+
+export const useMediaTimer = (): UseMediaTimerProps => {
   const [timestamp, setTimestamp] = useState<number>(0);
 
   const updateElapsedTime = useCallback(() => {
@@ -12,7 +28,7 @@ export const useMediaTimer = () => {
 
   const timer = useTimer({ delay: 1000 / 24 }, updateElapsedTime);
 
-  const toggleTimerState = () => {
+  const toggle = () => {
     if (!timer.isStarted()) {
       timer.start();
     } else if (timer.isRunning()) {
@@ -22,13 +38,13 @@ export const useMediaTimer = () => {
     }
   };
 
-  const toggleTimerLabel = !timer.isStarted()
+  const toggleLabel = !timer.isStarted()
     ? "Start"
     : timer.isRunning()
       ? "Pause"
       : "Resume";
 
-  const resetTimer = () => {
+  const reset = () => {
     if (timer.isRunning()) {
       timer.start();
     } else {
@@ -36,7 +52,7 @@ export const useMediaTimer = () => {
     }
   };
 
-  const seekTimer = (milliseconds: number) => {
+  const seek = (milliseconds: number) => {
     const currentEpochMillis = dayjsUtc().valueOf();
     const startTime = currentEpochMillis - milliseconds;
     if (timer.isRunning()) {
@@ -48,10 +64,14 @@ export const useMediaTimer = () => {
   };
 
   return {
-    timestamp,
-    toggleTimerState,
-    toggleTimerLabel,
-    resetTimer,
-    seekTimer,
+    mediaTimerProperties: {
+      timestamp,
+      toggleLabel,
+    },
+    mediaTimerActions: {
+      toggle,
+      reset,
+      seek,
+    },
   };
 };

--- a/src/hooks/media-timer/useMediaTimer.tsx
+++ b/src/hooks/media-timer/useMediaTimer.tsx
@@ -21,5 +21,13 @@ export const useMediaTimer = () => {
     }
   };
 
-  return { timer, timestamp, toggleTimerState };
+  const resetTimer = () => {
+    if (timer.isRunning()) {
+      timer.start();
+    } else {
+      timer.stop();
+    }
+  };
+
+  return { timer, timestamp, toggleTimerState, resetTimer };
 };

--- a/src/hooks/media-timer/useMediaTimer.tsx
+++ b/src/hooks/media-timer/useMediaTimer.tsx
@@ -18,7 +18,7 @@ interface UseMediaTimerProps {
   mediaTimerActions: MediaTimerActions;
 }
 
-export const useMediaTimer = (): UseMediaTimerProps => {
+export const useMediaTimer = (fps: number): UseMediaTimerProps => {
   const [timestamp, setTimestamp] = useState<number>(0);
 
   const updateElapsedTime = useCallback(() => {
@@ -26,7 +26,7 @@ export const useMediaTimer = (): UseMediaTimerProps => {
     setTimestamp(elapsed);
   }, []);
 
-  const timer = useTimer({ delay: 1000 / 24 }, updateElapsedTime);
+  const timer = useTimer({ delay: 1000 / fps }, updateElapsedTime);
 
   const toggle = () => {
     if (!timer.isStarted()) {

--- a/src/hooks/media-timer/useMediaTimer.tsx
+++ b/src/hooks/media-timer/useMediaTimer.tsx
@@ -2,15 +2,21 @@ import { useTimer } from "react-use-precision-timer";
 import { useCallback, useState } from "react";
 import dayjsUtc from "../../utils/dayjs-config.ts";
 
+export type MediaTimerState = "running" | "paused" | "stopped";
+
 export interface MediaTimerProperties {
   timestamp: number;
   toggleLabel: string;
+  state: MediaTimerState;
 }
 
 export interface MediaTimerActions {
   toggle: () => void;
   reset: () => void;
   seek: (milliseconds: number) => void;
+  resume: () => void;
+  pause: () => void;
+  stop: () => void;
 }
 
 interface UseMediaTimerProps {
@@ -75,15 +81,25 @@ export const useMediaTimer = (fps: number): UseMediaTimerProps => {
     }
   };
 
+  const state = timer.isRunning()
+    ? "running"
+    : timer.isPaused()
+      ? "paused"
+      : "stopped";
+
   return {
     mediaTimerProperties: {
       timestamp,
       toggleLabel,
+      state,
     },
     mediaTimerActions: {
       toggle,
       reset,
       seek,
+      resume: timer.resume,
+      pause,
+      stop,
     },
   };
 };

--- a/src/hooks/media-timer/useMediaTimer.tsx
+++ b/src/hooks/media-timer/useMediaTimer.tsx
@@ -28,11 +28,23 @@ export const useMediaTimer = (fps: number): UseMediaTimerProps => {
 
   const timer = useTimer({ delay: 1000 / fps }, updateElapsedTime);
 
+  const pause = () => {
+    // callback is not called in useTimer when timer is not running
+    timer.pause();
+    updateElapsedTime();
+  };
+
+  const stop = () => {
+    // callback is not called in useTimer when timer is not running
+    timer.stop();
+    updateElapsedTime();
+  };
+
   const toggle = () => {
     if (!timer.isStarted()) {
       timer.start();
     } else if (timer.isRunning()) {
-      timer.pause();
+      pause();
     } else {
       timer.resume();
     }
@@ -48,7 +60,7 @@ export const useMediaTimer = (fps: number): UseMediaTimerProps => {
     if (timer.isRunning()) {
       timer.start();
     } else {
-      timer.stop();
+      stop();
     }
   };
 
@@ -59,7 +71,7 @@ export const useMediaTimer = (fps: number): UseMediaTimerProps => {
       timer.start(startTime);
     } else {
       timer.start(startTime);
-      timer.pause();
+      pause();
     }
   };
 

--- a/src/hooks/media-timer/useMediaTimer.tsx
+++ b/src/hooks/media-timer/useMediaTimer.tsx
@@ -22,6 +22,12 @@ export const useMediaTimer = () => {
     }
   };
 
+  const toggleTimerLabel = !timer.isStarted()
+    ? "Start"
+    : timer.isRunning()
+      ? "Pause"
+      : "Resume";
+
   const resetTimer = () => {
     if (timer.isRunning()) {
       timer.start();
@@ -41,5 +47,11 @@ export const useMediaTimer = () => {
     }
   };
 
-  return { timer, timestamp, toggleTimerState, resetTimer, seekTimer };
+  return {
+    timestamp,
+    toggleTimerState,
+    toggleTimerLabel,
+    resetTimer,
+    seekTimer,
+  };
 };

--- a/src/hooks/media-timer/useMediaTimer.tsx
+++ b/src/hooks/media-timer/useMediaTimer.tsx
@@ -1,0 +1,15 @@
+import { useTimer } from "react-use-precision-timer";
+import { useCallback, useState } from "react";
+
+export const useMediaTimer = () => {
+  const [timestamp, setTimestamp] = useState<number>(0);
+
+  const updateElapsedTime = useCallback(() => {
+    const elapsed = timer.getElapsedRunningTime();
+    setTimestamp(elapsed);
+  }, []);
+
+  const timer = useTimer({ delay: 1000 / 24 }, updateElapsedTime);
+
+  return { timer, timestamp };
+};

--- a/src/hooks/media-timer/useMediaTimer.tsx
+++ b/src/hooks/media-timer/useMediaTimer.tsx
@@ -1,5 +1,6 @@
 import { useTimer } from "react-use-precision-timer";
 import { useCallback, useState } from "react";
+import dayjsUtc from "../../utils/dayjs-config.ts";
 
 export const useMediaTimer = () => {
   const [timestamp, setTimestamp] = useState<number>(0);
@@ -29,5 +30,16 @@ export const useMediaTimer = () => {
     }
   };
 
-  return { timer, timestamp, toggleTimerState, resetTimer };
+  const seekTimer = (milliseconds: number) => {
+    const currentEpochMillis = dayjsUtc().valueOf();
+    const startTime = currentEpochMillis - milliseconds;
+    if (timer.isRunning()) {
+      timer.start(startTime);
+    } else {
+      timer.start(startTime);
+      timer.pause();
+    }
+  };
+
+  return { timer, timestamp, toggleTimerState, resetTimer, seekTimer };
 };

--- a/src/hooks/plex/usePlex.ts
+++ b/src/hooks/plex/usePlex.ts
@@ -1,24 +1,15 @@
 import { usePlexSession } from "./usePlexSession.ts";
 import { usePlexMetadata } from "./usePlexMetadata.ts";
-import { useEffect, useMemo, useState } from "react";
-import { PlexAPI } from "@lukehagar/plexjs";
+import { useEffect, useState } from "react";
 import { ServerProtocol } from "@lukehagar/plexjs/src/lib/config.ts";
+import { usePlexApi } from "./usePlexApi.ts";
 
 export const usePlex = (
   plexIp: string,
   plexToken: string,
   protocol: ServerProtocol,
 ) => {
-  const plexApi = useMemo(() => {
-    if (plexIp && plexToken) {
-      return new PlexAPI({
-        ip: plexIp,
-        accessToken: plexToken,
-        protocol: protocol,
-      });
-    }
-  }, [plexIp, plexToken]);
-
+  const plexApi = usePlexApi(plexIp, plexToken, protocol);
   const { session, error: sessionError } = usePlexSession(plexApi, 200);
 
   const ratingKey = session?.ratingKey

--- a/src/hooks/plex/usePlex.ts
+++ b/src/hooks/plex/usePlex.ts
@@ -2,13 +2,19 @@ import { usePlexSession } from "./usePlexSession.ts";
 import { usePlexMetadata } from "./usePlexMetadata.ts";
 import { useEffect, useMemo, useState } from "react";
 import { PlexAPI } from "@lukehagar/plexjs";
+import { ServerProtocol } from "@lukehagar/plexjs/src/lib/config.ts";
 
-export const usePlex = (plexIp: string, plexToken: string) => {
+export const usePlex = (
+  plexIp: string,
+  plexToken: string,
+  protocol: ServerProtocol,
+) => {
   const plexApi = useMemo(() => {
     if (plexIp && plexToken) {
       return new PlexAPI({
         ip: plexIp,
         accessToken: plexToken,
+        protocol: protocol,
       });
     }
   }, [plexIp, plexToken]);

--- a/src/hooks/plex/usePlex.ts
+++ b/src/hooks/plex/usePlex.ts
@@ -4,63 +4,60 @@ import { useEffect, useState } from "react";
 import { usePlexApi } from "./usePlexApi.ts";
 
 export const usePlex = () => {
-  const { plexApi, plexApiOptions, setPlexApiOptions } = usePlexApi();
-  const { session, error: sessionError } = usePlexSession(plexApi, 200);
+  const {
+    plexApi,
+    plexApiOptions,
+    setPlexApiOptions,
+    plexServerCapabilities,
+    plexServerCapabilitiesError,
+  } = usePlexApi();
+
+  const { session } = usePlexSession(plexApi, 1000);
 
   const ratingKey = session?.ratingKey
     ? parseInt(session.ratingKey)
     : undefined;
-  const { metadata, error: metadataError } = usePlexMetadata(
-    plexApi,
-    ratingKey,
-  );
+
+  const { metadata } = usePlexMetadata(plexApi, ratingKey);
 
   const metadataGuidImdb = metadata?.guids?.find((guid) =>
     guid.id.includes("imdb://"),
   );
   const imdbId = metadataGuidImdb?.id?.split("//")?.at(1);
 
-  const viewOffset = session?.viewOffset;
-  const playerState = session?.player?.state;
+  const viewOffset = session?.viewOffset ?? 0;
+  const playerState = session?.player?.state ?? "empty";
   const mediaDuration = session?.duration;
 
-  const [lastPlayerState, setLastPlayerState] = useState<string>("unknown");
-  const [lastViewOffset, setLastViewOffset] = useState<number>(0);
-  const [lastUpdated, setLastUpdated] = useState<number>(0);
+  const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
+  const [lastPlayerState, setLastPlayerState] = useState(playerState);
+  const [lastViewOffset, setLastViewOffset] = useState(viewOffset);
 
   useEffect(() => {
-    if (
-      playerState === "playing" &&
-      lastPlayerState !== playerState &&
-      viewOffset !== undefined
-    ) {
-      setLastViewOffset(viewOffset);
-      setLastPlayerState(playerState);
-    }
-    if (playerState === "paused" && viewOffset !== undefined) {
-      setLastViewOffset(viewOffset);
-    }
-    if (playerState === undefined) {
-      setLastViewOffset(0);
-    }
     setLastUpdated(Date.now());
-  }, [lastPlayerState, playerState, viewOffset]);
+    setLastPlayerState(playerState);
+    setLastViewOffset(viewOffset);
+  }, [playerState, viewOffset]);
+
+  const different =
+    playerState !== lastPlayerState || viewOffset !== lastViewOffset;
+
+  const timeSinceLastUpdate = different ? 0 : Date.now() - lastUpdated;
 
   // The Plex API does not update the viewOffset very regularly, so we must make an educated guess at the timestamp
-  //  based on the last available viewOffset, and when we witnessed viewOffset update
-  const timeSinceLastUpdate = Date.now() - lastUpdated;
+  //  based on when we last witnessed an API state update
+
   const estimatedPlayTime =
-    playerState === "playing"
-      ? lastViewOffset + timeSinceLastUpdate
-      : lastViewOffset;
+    playerState === "playing" ? viewOffset + timeSinceLastUpdate : viewOffset;
 
   return {
     imdbId,
     estimatedPlayTime,
     playerState,
     mediaDuration,
-    error: sessionError ?? metadataError,
     plexApiOptions,
     setPlexApiOptions,
+    plexServerCapabilities,
+    plexServerCapabilitiesError,
   };
 };

--- a/src/hooks/plex/usePlex.ts
+++ b/src/hooks/plex/usePlex.ts
@@ -1,15 +1,10 @@
 import { usePlexSession } from "./usePlexSession.ts";
 import { usePlexMetadata } from "./usePlexMetadata.ts";
 import { useEffect, useState } from "react";
-import { ServerProtocol } from "@lukehagar/plexjs/src/lib/config.ts";
 import { usePlexApi } from "./usePlexApi.ts";
 
-export const usePlex = (
-  plexIp: string,
-  plexToken: string,
-  protocol: ServerProtocol,
-) => {
-  const plexApi = usePlexApi(plexIp, plexToken, protocol);
+export const usePlex = () => {
+  const { plexApi, plexApiOptions, setPlexApiOptions } = usePlexApi();
   const { session, error: sessionError } = usePlexSession(plexApi, 200);
 
   const ratingKey = session?.ratingKey
@@ -65,5 +60,7 @@ export const usePlex = (
     playerState,
     mediaDuration,
     error: sessionError ?? metadataError,
+    plexApiOptions,
+    setPlexApiOptions,
   };
 };

--- a/src/hooks/plex/usePlexApi.ts
+++ b/src/hooks/plex/usePlexApi.ts
@@ -1,0 +1,19 @@
+import { useMemo } from "react";
+import { PlexAPI } from "@lukehagar/plexjs";
+import { ServerProtocol } from "@lukehagar/plexjs/src/lib/config.ts";
+
+export const usePlexApi = (
+  plexIp: string,
+  plexToken: string,
+  protocol: ServerProtocol,
+) => {
+  return useMemo(() => {
+    if (plexIp && plexToken) {
+      return new PlexAPI({
+        ip: plexIp,
+        accessToken: plexToken,
+        protocol: protocol,
+      });
+    }
+  }, [plexIp, plexToken]);
+};

--- a/src/hooks/plex/usePlexApi.ts
+++ b/src/hooks/plex/usePlexApi.ts
@@ -49,9 +49,9 @@ export const usePlexApi = (): UsePlexApiReturnProps => {
     () => {
       setPlexApiWithTest(plexApiOptions);
     },
-    [
-      // causes infinite renders when plexApiOptions is included in the dependency array
-    ],
+    // causes infinite renders when plexApiOptions is included in the dependency array
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
   );
 
   return {

--- a/src/hooks/plex/usePlexApi.ts
+++ b/src/hooks/plex/usePlexApi.ts
@@ -40,14 +40,24 @@ export const usePlexApi = (): UsePlexApiReturnProps => {
       });
   };
 
-  useEffect(() => {
-    setPlexApiWithTest(plexApiOptions);
-  }, [plexApiOptions]);
+  const setPlexApiOptionsWithTest = (options: SDKOptions) => {
+    setPlexApiOptions(options);
+    setPlexApiWithTest(options);
+  };
+
+  useEffect(
+    () => {
+      setPlexApiWithTest(plexApiOptions);
+    },
+    [
+      // causes infinite renders when plexApiOptions is included in the dependency array
+    ],
+  );
 
   return {
     plexApi,
     plexApiOptions,
-    setPlexApiOptions,
+    setPlexApiOptions: setPlexApiOptionsWithTest,
     plexServerCapabilities,
     plexServerCapabilitiesError,
   };

--- a/src/hooks/plex/usePlexApi.ts
+++ b/src/hooks/plex/usePlexApi.ts
@@ -1,19 +1,18 @@
 import { useMemo } from "react";
-import { PlexAPI } from "@lukehagar/plexjs";
-import { ServerProtocol } from "@lukehagar/plexjs/src/lib/config.ts";
+import { PlexAPI, SDKOptions } from "@lukehagar/plexjs";
+import { useLocalStorage } from "usehooks-ts";
 
-export const usePlexApi = (
-  plexIp: string,
-  plexToken: string,
-  protocol: ServerProtocol,
-) => {
-  return useMemo(() => {
-    if (plexIp && plexToken) {
-      return new PlexAPI({
-        ip: plexIp,
-        accessToken: plexToken,
-        protocol: protocol,
-      });
-    }
-  }, [plexIp, plexToken]);
+export const usePlexApi = () => {
+  const [plexApiOptions, setPlexApiOptions] = useLocalStorage<SDKOptions>(
+    "plex-api-options",
+    {},
+  );
+
+  const plexApi = useMemo(() => new PlexAPI(plexApiOptions), [plexApiOptions]);
+
+  return {
+    plexApi,
+    plexApiOptions,
+    setPlexApiOptions,
+  };
 };

--- a/src/hooks/plex/usePlexApi.ts
+++ b/src/hooks/plex/usePlexApi.ts
@@ -1,18 +1,59 @@
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import { PlexAPI, SDKOptions } from "@lukehagar/plexjs";
-import { useLocalStorage } from "usehooks-ts";
+import { GetServerCapabilitiesResponse } from "@lukehagar/plexjs/sdk/models/operations";
+import { useLocalStorage } from "@uidotdev/usehooks";
 
-export const usePlexApi = () => {
+export interface UsePlexApiReturnProps {
+  plexApi: PlexAPI | null;
+  plexApiOptions: SDKOptions;
+  setPlexApiOptions: (options: SDKOptions) => void;
+  plexServerCapabilities: GetServerCapabilitiesResponse | null;
+  plexServerCapabilitiesError: Error | null;
+}
+
+export const usePlexApi = (): UsePlexApiReturnProps => {
   const [plexApiOptions, setPlexApiOptions] = useLocalStorage<SDKOptions>(
     "plex-api-options",
     {},
   );
 
-  const plexApi = useMemo(() => new PlexAPI(plexApiOptions), [plexApiOptions]);
+  const [plexApi, setPlexApi] = useState<PlexAPI | null>(null);
+  const [plexServerCapabilities, setPlexServerCapabilities] =
+    useState<GetServerCapabilitiesResponse | null>(null);
+  const [plexServerCapabilitiesError, setPlexServerCapabilitiesError] =
+    useState<Error | null>(null);
+
+  const setPlexApiWithTest = (options: SDKOptions) => {
+    const plexApi = new PlexAPI({ ...options, timeoutMs: 500 });
+
+    plexApi?.server
+      .getServerCapabilities()
+      .then((value) => {
+        setPlexServerCapabilities(value);
+        setPlexServerCapabilitiesError(null);
+        setPlexApi(plexApi);
+      })
+      .catch((reason: Error) => {
+        setPlexServerCapabilities(null);
+        setPlexServerCapabilitiesError(reason);
+        setPlexApi(null);
+      });
+  };
+
+  const setPlexApiOptionsWithTest = (options: SDKOptions) => {
+    setPlexApiOptions(options);
+    setPlexApiWithTest(options);
+  };
+
+  useEffect(() => {
+    setPlexApiWithTest(plexApiOptions);
+  }, []);
 
   return {
     plexApi,
     plexApiOptions,
-    setPlexApiOptions,
+    setPlexApiOptions: setPlexApiOptionsWithTest,
+    plexServerCapabilities,
+    plexServerCapabilitiesError,
   };
 };

--- a/src/hooks/plex/usePlexMetadata.ts
+++ b/src/hooks/plex/usePlexMetadata.ts
@@ -8,7 +8,7 @@ export const usePlexMetadata = (
 ) => {
   const [metadataResponse, setMetadataResponse] =
     useState<GetMediaMetaDataResponse | null>(null);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<any>(null);
 
   useEffect(() => {
     let isMounted = true;

--- a/src/hooks/plex/usePlexMetadata.ts
+++ b/src/hooks/plex/usePlexMetadata.ts
@@ -3,7 +3,7 @@ import { GetMediaMetaDataResponse } from "@lukehagar/plexjs/sdk/models/operation
 import { PlexAPI } from "@lukehagar/plexjs";
 
 export const usePlexMetadata = (
-  plexApi: PlexAPI | undefined,
+  plexApi: PlexAPI | null,
   ratingKey: number | undefined,
 ) => {
   const [metadataResponse, setMetadataResponse] =

--- a/src/hooks/plex/usePlexSession.ts
+++ b/src/hooks/plex/usePlexSession.ts
@@ -1,12 +1,9 @@
 import { useState } from "react";
 import { GetSessionsResponse } from "@lukehagar/plexjs/sdk/models/operations";
-import { useInterval } from "usehooks-ts";
 import { PlexAPI } from "@lukehagar/plexjs";
+import { useInterval } from "usehooks-ts";
 
-export const usePlexSession = (
-  plexApi: PlexAPI | undefined,
-  interval: number,
-) => {
+export const usePlexSession = (plexApi: PlexAPI | null, interval: number) => {
   const [sessionsResponse, setSessionsResponse] =
     useState<GetSessionsResponse | null>(null);
   const [error, setError] = useState<any>(null);

--- a/src/hooks/plex/usePlexSession.ts
+++ b/src/hooks/plex/usePlexSession.ts
@@ -9,7 +9,7 @@ export const usePlexSession = (
 ) => {
   const [sessionsResponse, setSessionsResponse] =
     useState<GetSessionsResponse | null>(null);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<any>(null);
 
   useInterval(() => {
     let isMounted = true;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
-import { StingComponent } from "./components/sting-component/sting-component";
+import { GamgeeApp } from "./components/gamgee-app/gamgee-app.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <StingComponent />
+    <GamgeeApp />
   </StrictMode>,
 );

--- a/src/movies/movies.ts
+++ b/src/movies/movies.ts
@@ -1,7 +1,7 @@
 import differencesTheTwoTowers from "./tt0167261/extended/differences.json" with { type: "json" };
 import chaptersTheTwoTowers from "./tt0167261/extended/chapters.json" with { type: "json" };
 
-type EditionDifferenceData = {
+export type EditionDifferenceData = {
   start_time: string;
   start_time_ms: number;
   end_time: string;
@@ -9,25 +9,25 @@ type EditionDifferenceData = {
   type: string;
 };
 
-type EditionChapter = {
+export type EditionChapter = {
   start_time: string;
   start_time_ms: number;
   title: string;
 };
 
-type MovieEdition = {
+export type MovieEdition = {
   label: string;
   duration: number;
   chapters?: EditionChapter[]; // TODO make required field once we have all the data
   differences?: EditionDifferenceData[]; // TODO make required field once we have all the data
 };
 
-type Movie = {
+export type Movie = {
   title: string;
   editions: MovieEdition[];
 };
 
-type Movies = { [key: string]: Movie };
+export type Movies = { [key: string]: Movie };
 
 export const movies: Movies = {
   tt0120737: {

--- a/src/movies/movies.ts
+++ b/src/movies/movies.ts
@@ -24,14 +24,14 @@ export type MovieEdition = {
 
 export type Movie = {
   title: string;
+  imdbId: string;
   editions: MovieEdition[];
 };
 
-export type Movies = { [key: string]: Movie };
-
-export const movies: Movies = {
-  tt0120737: {
+export const movies = [
+  {
     title: "The Lord of the Rings: The Fellowship of the Ring",
+    imdbId: "tt0120737",
     editions: [
       {
         label: "Theatrical Edition",
@@ -43,8 +43,9 @@ export const movies: Movies = {
       },
     ],
   },
-  tt0167261: {
+  {
     title: "The Lord of the Rings: The Two Towers",
+    imdbId: "tt0167261",
     editions: [
       {
         label: "Theatrical Edition",
@@ -58,8 +59,9 @@ export const movies: Movies = {
       },
     ],
   },
-  tt0167260: {
+  {
     title: "The Lord of the Rings: The Return of the King",
+    imdbId: "tt0167260",
     editions: [
       {
         label: "Theatrical Edition",
@@ -71,4 +73,7 @@ export const movies: Movies = {
       },
     ],
   },
-};
+] as const satisfies Movie[];
+
+export type ImdbId = (typeof movies)[number]["imdbId"];
+export const imdbIds = movies.map((movie) => movie.imdbId);

--- a/src/utils/dayjs-config.ts
+++ b/src/utils/dayjs-config.ts
@@ -1,0 +1,8 @@
+import dayjs, { Dayjs } from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+// Extend dayjs with plugins globally
+dayjs.extend(utc);
+
+export default dayjs.utc;
+export type { Dayjs };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
Adds the concept of a metadata provider, which provides the app with information on which movie/edition is being played, as well as controlling the in app timer.

Manual Metadata Provider:
- Dropdown for movie
- Dropdown for movie edition
- Manual playback controls

Plex Metadata Provider:
- Inputs for plex api options
- Automatically selects movie and edition
- Automatically syncs the timer with the plex server

Manual Provider | Plex Provider
--- | ---
<img width="470" alt="manual provider" src="https://github.com/user-attachments/assets/92615df7-b418-4400-923b-407a03f7fef8" /> | <img width="491" alt="plex provider" src="https://github.com/user-attachments/assets/95d18b3a-35cd-4a32-836c-ac4d1389f04a" />

There is some UI work to do, but will address that separately.
